### PR TITLE
gogio: refuse compilation with additional arguments

### DIFF
--- a/gogio/main.go
+++ b/gogio/main.go
@@ -65,6 +65,9 @@ func flagValidate() error {
 	if pkgPathArg == "" {
 		return errors.New("specify a package")
 	}
+	if len(flag.Args()) > 1 {
+		return fmt.Errorf(`invalid package path of "%s". Build argument must be specified before the package ("%s")`, strings.Join(flag.Args(), " "), pkgPathArg)
+	}
 	if *target == "" {
 		return errors.New("please specify -target")
 	}


### PR DESCRIPTION
Previously, it was possible to misuse gigio with arguments after the
package, such as `gogio -target android . -o foo.apk`. That cause an
undesired effect, since `-o` is silently ignore by gogio.

Now, any arguments after the package will trigger an error.

Signed-off-by: Inkeliz <inkeliz@inkeliz.com>