### PR TITLE
gogio: Set app name via command line

### DIFF
--- a/gogio/build_info.go
+++ b/gogio/build_info.go
@@ -37,12 +37,16 @@ func newBuildInfo(pkgPath string) (*buildInfo, error) {
 	if *iconPath != "" {
 		appIcon = *iconPath
 	}
+	appName := getPkgName(pkgMetadata)
+	if *name != "" {
+		appName = *name
+	}
 	bi := &buildInfo{
 		appID:    appID,
 		archs:    getArchs(),
 		ldflags:  getLdFlags(appID),
 		minsdk:   *minsdk,
-		name:     getPkgName(pkgMetadata),
+		name:     appName,
 		pkgDir:   pkgMetadata.Dir,
 		pkgPath:  pkgPath,
 		iconPath: appIcon,

--- a/gogio/main.go
+++ b/gogio/main.go
@@ -28,6 +28,7 @@ var (
 	buildMode     = flag.String("buildmode", "exe", "specify buildmode (archive, exe)")
 	destPath      = flag.String("o", "", "output file or directory.\nFor -target ios or tvos, use the .app suffix to target simulators.")
 	appID         = flag.String("appid", "", "app identifier (for -buildmode=exe)")
+	name          = flag.String("name", "", "app name (for -buildmode=exe)")
 	version       = flag.Int("version", 1, "app version (for -buildmode=exe)")
 	printCommands = flag.Bool("x", false, "print the commands")
 	keepWorkdir   = flag.Bool("work", false, "print the name of the temporary work directory and do not delete it when exiting.")


### PR DESCRIPTION
This allows the app name to have spaces and other characters not allowed in Go modules.