### PR TITLE
fix android build where it looks for jre

### DIFF
--- a/gogio/androidbuild.go
+++ b/gogio/androidbuild.go
@@ -769,7 +769,7 @@ func findKeytool() (string, error) {
 	if javaHome == "" {
 		return exec.LookPath("keytool")
 	}
-	keytool := filepath.Join(javaHome, "jre", "bin", "keytool"+exeSuffix)
+	keytool := filepath.Join(javaHome, "bin", "keytool"+exeSuffix)
 	if _, err := os.Stat(keytool); err != nil {
 		return "", err
 	}

--- a/gogio/androidbuild.go
+++ b/gogio/androidbuild.go
@@ -769,6 +769,8 @@ func findKeytool() (string, error) {
 	if javaHome == "" {
 		return exec.LookPath("keytool")
 	}
+
+	// bin, instead of "jre". "jre" was for older JVM it seems.
 	keytool := filepath.Join(javaHome, "bin", "keytool"+exeSuffix)
 	if _, err := os.Stat(keytool); err != nil {
 		return "", err


### PR DESCRIPTION
Android builds work but not the signing due to not finding the keytool.

JAVA_HOME is found but then it looks in the wrong location for the keytool file. Basically "jre" is no longer in the path if your using the latest JDK.

Bug is here: https://github.com/gioui/gio-cmd/blob/main/gogio/androidbuild.go#L772

func findKeytool() (string, error) {
	javaHome := os.Getenv("JAVA_HOME")
	if javaHome == "" {
		return exec.LookPath("keytool")
	}
	keytool := filepath.Join(javaHome, "jre", "bin", "keytool"+exeSuffix)
	if _, err := os.Stat(keytool); err != nil {
		return "", err
	}
	return keytool, nil
}
keytool := filepath.Join(javaHome, "jre", "bin", "keytool"+exeSuffix)

Its failing because the "jre" folder is no longer needed to get to the bin folder.

It should be:

keytool := filepath.Join(javaHome,, "bin", "keytool"+exeSuffix)

I did the change and it works with JAVA_HOME set or not set.