### PR TITLE
Add support for setting version name

### DIFF
--- a/gogio/androidbuild.go
+++ b/gogio/androidbuild.go
@@ -43,6 +43,7 @@ var exeSuffix string
 type manifestData struct {
 	AppID       string
 	Version     int
+	VersionName string
 	MinSDK      int
 	TargetSDK   int
 	Permissions []string
@@ -440,6 +441,7 @@ func exeAndroid(tmpDir string, tools *androidTools, bi *buildInfo, extraJars, pe
 	manifestSrc := manifestData{
 		AppID:       bi.appID,
 		Version:     bi.version,
+		VersionName: bi.versionName,
 		MinSDK:      minSDK,
 		TargetSDK:   targetSDK,
 		Permissions: permissions,
@@ -447,12 +449,15 @@ func exeAndroid(tmpDir string, tools *androidTools, bi *buildInfo, extraJars, pe
 		IconSnip:    iconSnip,
 		AppName:     appName,
 	}
+	if manifestSrc.VersionName == "" {
+		manifestSrc.VersionName = fmt.Sprintf("1.0.%d", bi.version)
+	}
 	tmpl, err := template.New("test").Parse(
 		`<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
 	package="{{.AppID}}"
 	android:versionCode="{{.Version}}"
-	android:versionName="1.0.{{.Version}}">
+	android:versionName="{{.VersionName}}">
 	<uses-sdk android:minSdkVersion="{{.MinSDK}}" android:targetSdkVersion="{{.TargetSDK}}" />
 {{range .Permissions}}	<uses-permission android:name="{{.}}"/>
 {{end}}{{range .Features}}	<uses-feature android:{{.}} android:required="false"/>

--- a/gogio/build_info.go
+++ b/gogio/build_info.go
@@ -23,6 +23,7 @@ type buildInfo struct {
 	tags           string
 	target         string
 	version        int
+	versionName    string
 	key            string
 	password       string
 	notaryAppleID  string
@@ -56,6 +57,7 @@ func newBuildInfo(pkgPath string) (*buildInfo, error) {
 		tags:           *extraTags,
 		target:         *target,
 		version:        *version,
+		versionName:    *versionName,
 		key:            *signKey,
 		password:       *signPass,
 		notaryAppleID:  *notaryID,

--- a/gogio/iosbuild.go
+++ b/gogio/iosbuild.go
@@ -319,6 +319,10 @@ func buildInfoPlist(bi *buildInfo) string {
 	case "tvos":
 		supportPlatform = "AppleTVOS"
 	}
+	versionName := bi.versionName
+	if versionName == "" {
+		versionName = fmt.Sprintf("1.0.%d", bi.version)
+	}
 	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -336,7 +340,7 @@ func buildInfoPlist(bi *buildInfo) string {
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.%d</string>
+	<string>%s</string>
 	<key>CFBundleVersion</key>
 	<string>%d</string>
 	<key>UILaunchStoryboardName</key>
@@ -377,7 +381,7 @@ func buildInfoPlist(bi *buildInfo) string {
 	<key>DTXcodeBuild</key>
 	<string>10G8</string>
 </dict>
-</plist>`, appName, bi.appID, appName, bi.version, bi.version, platform, minIOSVersion, supportPlatform, platform)
+</plist>`, appName, bi.appID, appName, versionName, bi.version, platform, minIOSVersion, supportPlatform, platform)
 }
 
 func iosPlatformFor(target string) string {

--- a/gogio/main.go
+++ b/gogio/main.go
@@ -30,6 +30,7 @@ var (
 	appID         = flag.String("appid", "", "app identifier (for -buildmode=exe)")
 	name          = flag.String("name", "", "app name (for -buildmode=exe)")
 	version       = flag.Int("version", 1, "app version (for -buildmode=exe)")
+	versionName   = flag.String("versionname", "", "app version name (for -buildmode=exe)")
 	printCommands = flag.Bool("x", false, "print the commands")
 	keepWorkdir   = flag.Bool("work", false, "print the name of the temporary work directory and do not delete it when exiting.")
 	linkMode      = flag.String("linkmode", "", "set the -linkmode flag of the go tool")

--- a/gogio/windowsbuild.go
+++ b/gogio/windowsbuild.go
@@ -44,6 +44,12 @@ func buildWindows(tmpDir string, bi *buildInfo) error {
 	if bi.version > math.MaxUint16 {
 		return fmt.Errorf("version (%d) is larger than the maximum (%d)", bi.version, math.MaxUint16)
 	}
+	versionName := bi.versionName
+	if versionName == "" {
+		versionName = "1.0.0." + version
+	} else if strings.Count(versionName, ".") < 3 {
+		versionName += ".0"
+	}
 
 	for _, arch := range bi.archs {
 		builder.Coff = coff.NewRSRC()
@@ -54,7 +60,7 @@ func buildWindows(tmpDir string, bi *buildInfo) error {
 		}
 
 		if err := builder.embedManifest(windowsManifest{
-			Version:        "1.0.0." + version,
+			Version:        versionName,
 			WindowsVersion: sdk,
 			Name:           name,
 		}); err != nil {
@@ -63,7 +69,7 @@ func buildWindows(tmpDir string, bi *buildInfo) error {
 
 		if err := builder.embedInfo(windowsResources{
 			Version:      [2]uint32{uint32(1) << 16, uint32(bi.version)},
-			VersionHuman: "1.0.0." + version,
+			VersionHuman: versionName,
 			Name:         name,
 			Language:     0x0400, // Process Default Language: https://docs.microsoft.com/en-us/previous-versions/ms957130(v=msdn.10)
 		}); err != nil {


### PR DESCRIPTION
Now apart from a numeric `-version` flag, `-versionname` can be set to a human-readable version number, as seen in the app info on Android/Mac/Windows.