### PR TITLE
gogio: add -tags to 'go list' command

### DIFF
--- a/gogio/androidbuild.go
+++ b/gogio/androidbuild.go
@@ -240,7 +240,7 @@ func compileAndroid(tmpDir string, tools *androidTools, bi *buildInfo) (err erro
 			return err
 		})
 	}
-	appDir, err := runCmd(exec.Command("go", "list", "-f", "{{.Dir}}", "gioui.org/app/"))
+	appDir, err := runCmd(exec.Command("go", "list", "-tags", bi.tags, "-f", "{{.Dir}}", "gioui.org/app/"))
 	if err != nil {
 		return err
 	}

--- a/gogio/build_info.go
+++ b/gogio/build_info.go
@@ -114,11 +114,11 @@ type packageMetadata struct {
 }
 
 func getPkgMetadata(pkgPath string) (*packageMetadata, error) {
-	pkgImportPath, err := runCmd(exec.Command("go", "list", "-f", "{{.ImportPath}}", pkgPath))
+	pkgImportPath, err := runCmd(exec.Command("go", "list", "-tags", *extraTags, "-f", "{{.ImportPath}}", pkgPath))
 	if err != nil {
 		return nil, err
 	}
-	pkgDir, err := runCmd(exec.Command("go", "list", "-f", "{{.Dir}}", pkgPath))
+	pkgDir, err := runCmd(exec.Command("go", "list", "-tags", *extraTags, "-f", "{{.Dir}}", pkgPath))
 	if err != nil {
 		return nil, err
 	}

--- a/gogio/iosbuild.go
+++ b/gogio/iosbuild.go
@@ -460,7 +460,7 @@ func archiveIOS(tmpDir, target, frameworkRoot string, bi *buildInfo) error {
 	if _, err := runCmd(lipo); err != nil {
 		return err
 	}
-	appDir, err := runCmd(exec.Command("go", "list", "-f", "{{.Dir}}", "gioui.org/app/"))
+	appDir, err := runCmd(exec.Command("go", "list", "-tags", tags, "-f", "{{.Dir}}", "gioui.org/app/"))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR fixes a bug where gogio doesn't pass argument -tags to "go list"