### PR TITLE
gogio: [Android] add -targetsdk flag to specify the target SDK level

### DIFF
--- a/gogio/androidbuild.go
+++ b/gogio/androidbuild.go
@@ -352,14 +352,17 @@ func exeAndroid(tmpDir string, tools *androidTools, bi *buildInfo, extraJars, pe
 	if err := os.MkdirAll(dexDir, 0755); err != nil {
 		return err
 	}
-	// https://developer.android.com/distribute/best-practices/develop/target-sdk
-	targetSDK := 31
-	if bi.minsdk > targetSDK {
-		targetSDK = bi.minsdk
-	}
 	minSDK := 16
 	if bi.minsdk > minSDK {
 		minSDK = bi.minsdk
+	}
+	// https://developer.android.com/distribute/best-practices/develop/target-sdk
+	targetSDK := 33
+	if bi.targetsdk > 0 {
+		targetSDK = bi.targetsdk
+	}
+	if minSDK > targetSDK {
+		targetSDK = minSDK
 	}
 	if len(classFiles) > 0 {
 		d8 := exec.Command(

--- a/gogio/build_info.go
+++ b/gogio/build_info.go
@@ -18,6 +18,7 @@ type buildInfo struct {
 	archs          []string
 	ldflags        string
 	minsdk         int
+	targetsdk      int
 	name           string
 	pkgDir         string
 	pkgPath        string
@@ -60,6 +61,7 @@ func newBuildInfo(pkgPath string) (*buildInfo, error) {
 		archs:          getArchs(),
 		ldflags:        getLdFlags(appID),
 		minsdk:         *minsdk,
+		targetsdk:      *targetsdk,
 		name:           appName,
 		pkgDir:         pkgMetadata.Dir,
 		pkgPath:        pkgPath,

--- a/gogio/help.go
+++ b/gogio/help.go
@@ -59,6 +59,9 @@ use -mindk 10 to target Windows 10 and later, -minsdk 6 for Windows Vista and la
 For iOS builds the -minsdk flag specify the minimum iOS version. For example, 
 use -mindk 15 to target iOS 15.0 and later.
 
+For Android builds the -targetsdk flag specify the target SDK level. For example,
+use -targetsdk 33 to target Android 13 (Tiramisu) and later.
+
 The -work flag prints the path to the working directory and suppress
 its deletion.
 

--- a/gogio/main.go
+++ b/gogio/main.go
@@ -24,6 +24,7 @@ var (
 	target        = flag.String("target", "", "specify target (ios, tvos, android, js).\n")
 	archNames     = flag.String("arch", "", "specify architecture(s) to include (arm, arm64, amd64).")
 	minsdk        = flag.Int("minsdk", 0, "specify the minimum supported operating system level")
+	targetsdk     = flag.Int("targetsdk", 0, "specify the target supported operating system level for Android")
 	buildMode     = flag.String("buildmode", "exe", "specify buildmode (archive, exe)")
 	destPath      = flag.String("o", "", "output file or directory.\nFor -target ios or tvos, use the .app suffix to target simulators.")
 	appID         = flag.String("appid", "", "app identifier (for -buildmode=exe)")


### PR DESCRIPTION
This PR allows user to specify the target SDK level for Android via the `-targetsdk` command line flag.