### PR TITLE
fix: [Android] support Android 15+ with 16KB page-size

### DIFF
--- a/gogio/androidbuild.go
+++ b/gogio/androidbuild.go
@@ -217,7 +217,7 @@ func compileAndroid(tmpDir string, tools *androidTools, bi *buildInfo) (err erro
 		cmd := exec.Command(
 			"go",
 			"build",
-			"-ldflags=-w -s "+bi.ldflags,
+			"-ldflags=-w -s -extldflags \"-Wl,-z,max-page-size=65536\" "+bi.ldflags,
 			"-buildmode=c-shared",
 			"-tags", bi.tags,
 			"-o", libFile,


### PR DESCRIPTION
Previously, Gio crashes on 16KB page-size enable version of Android 15. Also, Google Play will require 16KB compatible apps by November 2025.

This patch changes the page-size of C/CGO to 64KB, which is compatible with 4KB, 16KB and 64KB. That is also the same value used by Golang Compiler itself.

------

Note: I went to 64KB instead of 16KB because Go already uses 64KB.